### PR TITLE
update socialize:cloudinary to 2.0.2 due to auto configuration bug

### DIFF
--- a/.meteor/versions
+++ b/.meteor/versions
@@ -100,7 +100,7 @@ routepolicy@1.1.1
 service-configuration@1.3.1
 sha@1.0.9
 shell-server@0.5.0
-socialize:cloudinary@2.0.1
+socialize:cloudinary@2.0.2
 socket-stream-client@0.5.0
 spacebars-compiler@1.3.1
 standard-minifier-css@1.8.2


### PR DESCRIPTION
Very sorry.. There was a bug in the most recently published version of my `socialize:cloudinary` package. I've published a new version and this PR updates the app to use the most current version.